### PR TITLE
Implement dynamic inputs and outputs.

### DIFF
--- a/mlblocks/mlblock.py
+++ b/mlblocks/mlblock.py
@@ -264,6 +264,8 @@ class MLBlock():
                 A dictionary containing the argument names and values to pass
                 to the primitive method.
         """
+        if isinstance(method_args, str):
+            method_args = getattr(self.instance, method_args)()
 
         method_kwargs = dict()
         for arg in method_args:

--- a/mlblocks/mlblock.py
+++ b/mlblocks/mlblock.py
@@ -111,8 +111,15 @@ class MLBlock():
             if name in kwargs:
                 init_params[name] = kwargs.pop(name)
 
-        fit_args = [arg['name'] for arg in self.fit_args]
-        produce_args = [arg['name'] for arg in self.produce_args]
+        if not isinstance(self.fit_args, str):
+            fit_args = [arg['name'] for arg in self.fit_args]
+        else:
+            fit_args = []
+
+        if not isinstance(self.produce_args, str):
+            produce_args = [arg['name'] for arg in self.produce_args]
+        else:
+            produce_args = []
 
         for name in list(kwargs.keys()):
             if name in fit_args:

--- a/mlblocks/mlpipeline.py
+++ b/mlblocks/mlpipeline.py
@@ -587,6 +587,10 @@ class MLPipeline():
 
         input_names = self.input_names.get(block_name, dict())
 
+        if isinstance(block_args, str):
+            block = self.blocks[block_name]
+            block_args = getattr(block.instance, block_args)()
+
         kwargs = dict()
         for arg in block_args:
             name = arg['name']
@@ -600,6 +604,9 @@ class MLPipeline():
     def _extract_outputs(self, block_name, outputs, block_outputs):
         """Extract the outputs of the method as a dict to be set into the context."""
         # TODO: type validation and/or transformation should be done here
+        if isinstance(block_outputs, str):
+            block = self.blocks[block_name]
+            block_outputs = getattr(block.instance, block_outputs)()
 
         if not isinstance(outputs, tuple):
             outputs = (outputs, )

--- a/mlblocks/mlpipeline.py
+++ b/mlblocks/mlpipeline.py
@@ -177,6 +177,9 @@ class MLPipeline():
         """
         block = self.blocks[block_name]
         variables = deepcopy(getattr(block, variables_attr))
+        if isinstance(variables, str):
+            variables = getattr(block.instance, variables)()
+
         variable_dict = {}
         for variable in variables:
             name = variable['name']
@@ -299,6 +302,12 @@ class MLPipeline():
                 inputs.update(fit_inputs)
 
         return inputs
+
+    def get_fit_args(self):
+        return list(self.get_inputs(fit=True).values())
+
+    def get_predict_args(self):
+        return list(self.get_inputs(fit=False).values())
 
     def get_outputs(self, outputs='default'):
         """Get the list of output variables that correspond to the specified outputs.

--- a/tests/test_mlpipeline.py
+++ b/tests/test_mlpipeline.py
@@ -550,7 +550,7 @@ class TestMLPipline(TestCase):
         assert names == ['a_variable']
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
-    def test__get_block_variables(self):
+    def test__get_block_variables_is_dict(self):
         expected = {
             'name_output': {
                 'name': 'output',
@@ -573,6 +573,34 @@ class TestMLPipline(TestCase):
             {'output': 'name_output'}
         )
         assert outputs == expected
+
+    @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
+    def test__get_block_variables_is_str(self):
+        expected = {
+            'output_from_function': {
+                'name': 'output_from_function',
+                'type': 'test',
+            }
+        }
+
+        pipeline = MLPipeline(['a_primitive'])
+
+        pipeline.blocks['a_primitive#1'].produce_outputs = 'get_produce_outputs'
+        pipeline.blocks['a_primitive#1'].instance.get_produce_outputs.return_value = [
+            {
+                'name': 'output_from_function',
+                'type': 'test'
+            }
+
+        ]
+
+        outputs = pipeline._get_block_variables(
+            'a_primitive#1',
+            'produce_outputs',
+            {'output': 'name_output'}
+        )
+        assert outputs == expected
+        pipeline.blocks['a_primitive#1'].instance.get_produce_outputs.assert_called_once_with()
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
     def test_get_inputs_fit(self):
@@ -680,6 +708,80 @@ class TestMLPipline(TestCase):
         inputs = pipeline.get_inputs(fit=False)
 
         assert inputs == expected
+
+    @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
+    def test_get_fit_args(self):
+        expected = [
+            {
+                'name': 'input',
+                'type': 'whatever'
+            },
+            {
+                'name': 'fit_input',
+                'type': 'whatever',
+            }
+        ]
+
+        pipeline = MLPipeline(['a_primitive'])
+
+        pipeline.blocks['a_primitive#1'].produce_args = [
+            {
+                'name': 'input',
+                'type': 'whatever'
+            }
+        ]
+
+        pipeline.blocks['a_primitive#1'].fit_args = [
+            {
+                'name': 'fit_input',
+                'type': 'whatever'
+            }
+        ]
+
+        pipeline.blocks['a_primitive#1'].produce_output = [
+            {
+                'name': 'output',
+                'type': 'another_whatever'
+            }
+        ]
+
+        outputs = pipeline.get_fit_args()
+        assert outputs == expected
+
+    @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
+    def test_get_predict_args(self):
+        expected = [
+            {
+                'name': 'input',
+                'type': 'whatever'
+            }
+        ]
+
+        pipeline = MLPipeline(['a_primitive'])
+
+        pipeline.blocks['a_primitive#1'].produce_args = [
+            {
+                'name': 'input',
+                'type': 'whatever'
+            }
+        ]
+
+        pipeline.blocks['a_primitive#1'].fit_args = [
+            {
+                'name': 'fit_input',
+                'type': 'whatever'
+            }
+        ]
+
+        pipeline.blocks['a_primitive#1'].produce_output = [
+            {
+                'name': 'output',
+                'type': 'another_whatever'
+            }
+        ]
+
+        outputs = pipeline.get_predict_args()
+        assert outputs == expected
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
     def test_fit_pending_all_primitives(self):

--- a/tests/test_mlpipeline.py
+++ b/tests/test_mlpipeline.py
@@ -381,6 +381,7 @@ class TestMLPipline(TestCase):
             ]
         }
         pipeline = MLPipeline(['a_primitive', 'another_primitive'], outputs=outputs)
+
         returned = pipeline.get_outputs('debug')
 
         expected = [
@@ -389,13 +390,11 @@ class TestMLPipline(TestCase):
                 'variable': 'another_variable',
             }
         ]
-
         assert returned == expected
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
     def test_get_outputs_str_variable(self):
         pipeline = MLPipeline(['a_primitive', 'another_primitive'])
-
         pipeline.blocks['a_primitive#1'].produce_output = [
             {
                 'name': 'output',
@@ -412,7 +411,6 @@ class TestMLPipline(TestCase):
                 'variable': 'a_primitive#1.output'
             }
         ]
-
         assert returned == expected
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
@@ -427,7 +425,6 @@ class TestMLPipline(TestCase):
                 'variable': 'a_primitive#1',
             }
         ]
-
         assert returned == expected
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
@@ -442,7 +439,6 @@ class TestMLPipline(TestCase):
                 'variable': 'another_primitive#1',
             }
         ]
-
         assert returned == expected
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
@@ -463,7 +459,6 @@ class TestMLPipline(TestCase):
             ]
         }
         pipeline = MLPipeline(['a_primitive', 'another_primitive'], outputs=outputs)
-
         pipeline.blocks['a_primitive#1'].produce_output = [
             {
                 'name': 'output',
@@ -498,7 +493,6 @@ class TestMLPipline(TestCase):
                 'variable': 'a_primitive#1.output'
             }
         ]
-
         assert returned == expected
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
@@ -551,15 +545,7 @@ class TestMLPipline(TestCase):
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
     def test__get_block_variables_is_dict(self):
-        expected = {
-            'name_output': {
-                'name': 'output',
-                'type': 'whatever',
-            }
-        }
-
         pipeline = MLPipeline(['a_primitive'])
-
         pipeline.blocks['a_primitive#1'].produce_outputs = [
             {
                 'name': 'output',
@@ -572,19 +558,18 @@ class TestMLPipline(TestCase):
             'produce_outputs',
             {'output': 'name_output'}
         )
+
+        expected = {
+            'name_output': {
+                'name': 'output',
+                'type': 'whatever',
+            }
+        }
         assert outputs == expected
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
     def test__get_block_variables_is_str(self):
-        expected = {
-            'output_from_function': {
-                'name': 'output_from_function',
-                'type': 'test',
-            }
-        }
-
         pipeline = MLPipeline(['a_primitive'])
-
         pipeline.blocks['a_primitive#1'].produce_outputs = 'get_produce_outputs'
         pipeline.blocks['a_primitive#1'].instance.get_produce_outputs.return_value = [
             {
@@ -599,11 +584,50 @@ class TestMLPipline(TestCase):
             'produce_outputs',
             {'output': 'name_output'}
         )
+
+        expected = {
+            'output_from_function': {
+                'name': 'output_from_function',
+                'type': 'test',
+            }
+        }
         assert outputs == expected
         pipeline.blocks['a_primitive#1'].instance.get_produce_outputs.assert_called_once_with()
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
     def test_get_inputs_fit(self):
+        pipeline = MLPipeline(['a_primitive', 'another_primitive'])
+        pipeline.blocks['a_primitive#1'].produce_args = [
+            {
+                'name': 'input',
+                'type': 'whatever'
+            }
+        ]
+        pipeline.blocks['a_primitive#1'].fit_args = [
+            {
+                'name': 'fit_input',
+                'type': 'whatever'
+            }
+        ]
+        pipeline.blocks['a_primitive#1'].produce_output = [
+            {
+                'name': 'output',
+                'type': 'another_whatever'
+            }
+        ]
+        pipeline.blocks['another_primitive#1'].produce_args = [
+            {
+                'name': 'output',
+                'type': 'another_whatever'
+            },
+            {
+                'name': 'another_input',
+                'type': 'another_whatever'
+            }
+        ]
+
+        inputs = pipeline.get_inputs()
+
         expected = {
             'input': {
                 'name': 'input',
@@ -617,83 +641,30 @@ class TestMLPipline(TestCase):
                 'name': 'another_input',
                 'type': 'another_whatever',
             }
-
         }
-
-        pipeline = MLPipeline(['a_primitive', 'another_primitive'])
-
-        pipeline.blocks['a_primitive#1'].produce_args = [
-            {
-                'name': 'input',
-                'type': 'whatever'
-            }
-        ]
-
-        pipeline.blocks['a_primitive#1'].fit_args = [
-            {
-                'name': 'fit_input',
-                'type': 'whatever'
-            }
-        ]
-
-        pipeline.blocks['a_primitive#1'].produce_output = [
-            {
-                'name': 'output',
-                'type': 'another_whatever'
-            }
-        ]
-
-        pipeline.blocks['another_primitive#1'].produce_args = [
-            {
-                'name': 'output',
-                'type': 'another_whatever'
-            },
-            {
-                'name': 'another_input',
-                'type': 'another_whatever'
-            }
-        ]
-
-        inputs = pipeline.get_inputs()
         assert inputs == expected
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
     def test_get_inputs_no_fit(self):
-        expected = {
-            'input': {
-                'name': 'input',
-                'type': 'whatever',
-            },
-            'another_input': {
-                'name': 'another_input',
-                'type': 'another_whatever',
-            }
-
-        }
-
         pipeline = MLPipeline(['a_primitive', 'another_primitive'])
-
         pipeline.blocks['a_primitive#1'].produce_args = [
             {
                 'name': 'input',
                 'type': 'whatever'
             }
         ]
-
         pipeline.blocks['a_primitive#1'].fit_args = [
             {
                 'name': 'fit_input',
                 'type': 'whatever'
             }
         ]
-
         pipeline.blocks['a_primitive#1'].produce_output = [
             {
                 'name': 'output',
                 'type': 'another_whatever'
             }
         ]
-
         pipeline.blocks['another_primitive#1'].produce_args = [
             {
                 'name': 'output',
@@ -707,10 +678,42 @@ class TestMLPipline(TestCase):
 
         inputs = pipeline.get_inputs(fit=False)
 
+        expected = {
+            'input': {
+                'name': 'input',
+                'type': 'whatever',
+            },
+            'another_input': {
+                'name': 'another_input',
+                'type': 'another_whatever',
+            }
+        }
         assert inputs == expected
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
     def test_get_fit_args(self):
+        pipeline = MLPipeline(['a_primitive'])
+        pipeline.blocks['a_primitive#1'].produce_args = [
+            {
+                'name': 'input',
+                'type': 'whatever'
+            }
+        ]
+        pipeline.blocks['a_primitive#1'].fit_args = [
+            {
+                'name': 'fit_input',
+                'type': 'whatever'
+            }
+        ]
+        pipeline.blocks['a_primitive#1'].produce_output = [
+            {
+                'name': 'output',
+                'type': 'another_whatever'
+            }
+        ]
+
+        outputs = pipeline.get_fit_args()
+
         expected = [
             {
                 'name': 'input',
@@ -721,66 +724,37 @@ class TestMLPipline(TestCase):
                 'type': 'whatever',
             }
         ]
+        assert outputs == expected
 
+    @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
+    def test_get_predict_args(self):
         pipeline = MLPipeline(['a_primitive'])
-
         pipeline.blocks['a_primitive#1'].produce_args = [
             {
                 'name': 'input',
                 'type': 'whatever'
             }
         ]
-
         pipeline.blocks['a_primitive#1'].fit_args = [
             {
                 'name': 'fit_input',
                 'type': 'whatever'
             }
         ]
-
         pipeline.blocks['a_primitive#1'].produce_output = [
             {
                 'name': 'output',
                 'type': 'another_whatever'
             }
         ]
+        outputs = pipeline.get_predict_args()
 
-        outputs = pipeline.get_fit_args()
-        assert outputs == expected
-
-    @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
-    def test_get_predict_args(self):
         expected = [
             {
                 'name': 'input',
                 'type': 'whatever'
             }
         ]
-
-        pipeline = MLPipeline(['a_primitive'])
-
-        pipeline.blocks['a_primitive#1'].produce_args = [
-            {
-                'name': 'input',
-                'type': 'whatever'
-            }
-        ]
-
-        pipeline.blocks['a_primitive#1'].fit_args = [
-            {
-                'name': 'fit_input',
-                'type': 'whatever'
-            }
-        ]
-
-        pipeline.blocks['a_primitive#1'].produce_output = [
-            {
-                'name': 'output',
-                'type': 'another_whatever'
-            }
-        ]
-
-        outputs = pipeline.get_predict_args()
         assert outputs == expected
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)


### PR DESCRIPTION
This pull request contains the code necessary to support the dynamic inputs and outputs where instead of obtaining the raw value from the `json` or `dict` we call a function if this is a `str`. 
Also two new methods are added for the `MLPipeline` called `get_fit_args` and `get_produce_args` which do exactly this function, return the inputs and outputs dynamically  for `MLPipeline` which will allow us to make this a `primitive` in our [MLPrimitives library](https://github.com/MLBazaar/MLPrimitives/).

Resolve #134 and helps solving the #116 