### PR TITLE
Update `numpy` dependency 

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,6 +21,8 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install package
       run: pip install .[dev]
+    - name: Install scikit-learn
+      run: pip install 'scikit-learn<1.1'
     - name: make test-devel
       run: make test-devel
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -46,7 +46,24 @@ jobs:
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-20.04, macos-latest]
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install package and dependencies
+      run: pip install .[dev]
+    - name: make test-unit
+      run: make test-unit
+
+  unit-mlprimitives:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8]
+        os: [ubuntu-20.04, macos-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -55,15 +72,15 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install package and dependencies
       run: pip install .[test]
-    - name: make test-unit
-      run: make test-unit
+    - name: make test-mlprimitives
+      run: make test-mlprimitives
 
   tutorials:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: [3.6, 3.7, 3.8]
-        os: [ubuntu-latest]
+        os: [ubuntu-20.04]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package
@@ -33,7 +33,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package and dependencies
@@ -50,11 +50,11 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package and dependencies
-      run: pip install .[dev]
+      run: pip install .[unit]
     - name: make test-unit
       run: make test-unit
 
@@ -67,7 +67,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install package and dependencies
@@ -84,10 +84,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v1
+      uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
-    - if: matrix.os == 'ubuntu-latest'
+    - if: matrix.os == 'ubuntu-20.04'
       name: Install dependencies - Ubuntu
       run: sudo apt-get install graphviz
     - name: Install package and dependencies

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,8 +21,6 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Install package
       run: pip install .[dev]
-    - name: Install scikit-learn
-      run: pip install 'scikit-learn<1.1'
     - name: make test-devel
       run: make test-devel
 

--- a/Makefile
+++ b/Makefile
@@ -136,7 +136,7 @@ test-tutorials: ## run the tutorial notebooks
 		jupyter nbconvert --execute --ExecutePreprocessor.timeout=3600 --stdout --to html {} > /dev/null +
 
 .PHONY: test
-test: test-unit test-features test-readme ## test everything that needs test dependencies
+test: test-unit test-mlprimitives test-readme ## test everything that needs test dependencies
 
 .PHONY: check-dependencies
 check-dependencies: ## test if there are any broken dependencies

--- a/Makefile
+++ b/Makefile
@@ -118,6 +118,10 @@ lint-docs: ## check docs formatting with doc8 and pydocstyle
 
 .PHONY: test-unit
 test-unit: ## run tests quickly with the default Python
+	python -m pytest --cov=mlblocks --ignore=tests/features/
+
+.PHONY: test-mlprimitives
+test-mlprimitives: ## run tests quickly with the default Python
 	python -m pytest --cov=mlblocks
 
 .PHONY: test-readme
@@ -132,7 +136,7 @@ test-tutorials: ## run the tutorial notebooks
 		jupyter nbconvert --execute --ExecutePreprocessor.timeout=3600 --stdout --to html {} > /dev/null +
 
 .PHONY: test
-test: test-unit test-readme ## test everything that needs test dependencies
+test: test-unit test-features test-readme ## test everything that needs test dependencies
 
 .PHONY: check-dependencies
 check-dependencies: ## test if there are any broken dependencies

--- a/docs/getting_started/quickstart.rst
+++ b/docs/getting_started/quickstart.rst
@@ -102,6 +102,7 @@ To do this, we first call the ``fit`` method passing the training data and the c
 labels.
 
 .. ipython:: python
+    :okwarning:
 
     from mlprimitives.datasets import load_census
     dataset = load_census()
@@ -112,6 +113,7 @@ Once we have fitted our model to our data, we can call the ``predict`` method pa
 to obtain predictions from the pipeline.
 
 .. ipython:: python
+    :okwarning:
 
     predictions = pipeline.predict(X_test)
     predictions

--- a/setup.py
+++ b/setup.py
@@ -95,7 +95,8 @@ setup(
     ],
     description='Pipelines and primitives for machine learning and data science.',
     extras_require={
-        'dev': development_requires + tests_require,
+        'dev': development_requires + tests_require + examples_require,
+        'unit': development_requires + tests_require,
         'test': tests_require + examples_require,
         'examples': examples_require,
         'mlprimitives': mlprimitives_requires,

--- a/setup.py
+++ b/setup.py
@@ -53,6 +53,7 @@ development_requires = [
     'watchdog>=0.8.3,<0.11',
 
     # docs
+    'docutils>=0.12,<0.18',
     'm2r>=0.2.0,<0.3',
     'Sphinx>=1.7.1,<3',
     'sphinx_rtd_theme>=0.2.4,<0.5',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('HISTORY.md', encoding='utf-8') as history_file:
 
 install_requires = [
     'graphviz>=0.9,<1',
-    'numpy>=1.17.1,<1.21',
+    'numpy>=1.17.1,<2',
     'psutil>=5,<6',
 ]
 
@@ -34,7 +34,6 @@ examples_require = mlprimitives_requires + [
 tests_require = [
     'pytest>=3.4.2',
     'pytest-cov>=2.6.0',
-    'mlprimitives>=0.3.0.dev0,<0.4',
     'setuptools>=41.0.0',
     'rundoc>=0.4.3',
     'prompt-toolkit>=2.0,<3.0',
@@ -96,7 +95,7 @@ setup(
     ],
     description='Pipelines and primitives for machine learning and data science.',
     extras_require={
-        'dev': development_requires + tests_require + examples_require,
+        'dev': development_requires + tests_require,
         'test': tests_require + examples_require,
         'examples': examples_require,
         'mlprimitives': mlprimitives_requires,

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ development_requires = [
     'ipython>=6.5.0',
     'autodocsumm>=0.1.10',
     'Jinja2>=2,<3', # >=3 makes sphinx theme fail
+    'markupsafe<2.1.0',
 
     # style check
     'flake8>=3.7.7,<4',

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ with open('HISTORY.md', encoding='utf-8') as history_file:
 
 install_requires = [
     'graphviz>=0.9,<1',
-    'numpy>=1.17.1,<1.19',
+    'numpy>=1.17.1,<1.21',
     'psutil>=5,<6',
 ]
 

--- a/setup.py
+++ b/setup.py
@@ -53,10 +53,10 @@ development_requires = [
     'watchdog>=0.8.3,<0.11',
 
     # docs
-    'docutils>=0.12,<0.18',
     'm2r>=0.2.0,<0.3',
     'Sphinx>=1.7.1,<3',
     'sphinx_rtd_theme>=0.2.4,<0.5',
+    'docutils>=0.12,<0.18',
     'ipython>=6.5.0',
     'autodocsumm>=0.1.10',
     'Jinja2>=2,<3', # >=3 makes sphinx theme fail

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ mlprimitives_requires = [
     'mlprimitives>=0.3.0,<0.4',
     'h5py<2.11.0,>=2.10.0',  # <- tensorflow 2.3.2 conflict
     'matplotlib<3.2.2,>=2.2.2',  # <- copulas 0.3.3
+    'protobuf<4', # <- importlib
 ]
 
 examples_require = mlprimitives_requires + [
@@ -57,6 +58,7 @@ development_requires = [
     'sphinx_rtd_theme>=0.2.4,<0.5',
     'ipython>=6.5.0',
     'autodocsumm>=0.1.10',
+    'Jinja2>=2,<3', # >=3 makes sphinx theme fail
 
     # style check
     'flake8>=3.7.7,<4',
@@ -96,7 +98,7 @@ setup(
     description='Pipelines and primitives for machine learning and data science.',
     extras_require={
         'dev': development_requires + tests_require + examples_require,
-        'unit': development_requires + tests_require,
+        'unit': tests_require,
         'test': tests_require + examples_require,
         'examples': examples_require,
         'mlprimitives': mlprimitives_requires,

--- a/tests/test_mlpipeline.py
+++ b/tests/test_mlpipeline.py
@@ -1124,7 +1124,7 @@ class TestMLPipline(TestCase):
         ]
         pipeline.blocks['a_primitive#1'].produce_output = output
 
-        assert str(pipeline.get_diagram()) == expected
+        assert str(pipeline.get_diagram()).strip() == expected.strip()
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
     def test_get_diagram_fit(self):
@@ -1155,7 +1155,7 @@ class TestMLPipline(TestCase):
         ]
         pipeline.blocks['a_primitive#1'].produce_output = output
 
-        assert str(pipeline.get_diagram()) == expected
+        assert str(pipeline.get_diagram()).strip() == expected.strip()
 
     @patch('mlblocks.mlpipeline.MLBlock', new=get_mlblock_mock)
     def test_get_diagram_multiple_blocks(self):
@@ -1189,7 +1189,7 @@ class TestMLPipline(TestCase):
         pipeline.blocks['b_primitive#1'].produce_args = first_output
         pipeline.blocks['b_primitive#1'].produce_output = second_output
 
-        assert str(pipeline.get_diagram()) == expected
+        assert str(pipeline.get_diagram()).strip() == expected.strip()
 
     def test_fit(self):
         pass


### PR DESCRIPTION
* cap `numpy` to the next major release "2".
* separate tests into mlblocks test "unit" and mlblocks + mlprimitives tests "unit-mlprimitives".
* update python3.6 actions support.